### PR TITLE
added syntax highliting support for dict variable

### DIFF
--- a/robot.tmLanguage
+++ b/robot.tmLanguage
@@ -69,7 +69,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>((?&lt;!\\)|(?&lt;=\\\\))[$@%]\{</string>
+			<string>((?&lt;!\\)|(?&lt;=\\\\))[$@&amp;%]\{</string>
 			<key>comment</key>
 			<string>${variables}. one backslash escapes the variable, two do not</string>
 			<key>end</key>


### PR DESCRIPTION
tiny change to support syntax highlighting for [dict variable introduced in RF 2.9](http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#dictionary-variables)
